### PR TITLE
Fix README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,29 +40,29 @@ Morley-IR/
 ## Usage
 # Convert Ladder Logic (.ll) into Morley-IR
 ```
-python src/ll_to_ir.py input.ll
+python src/ll_parser.py input.ll
 ```
 # Compile Morley-IR into Plutus Haskell
 ```
-python src/compile_ir_to_plutus.py input.ir
+python src/plutusladder_compiler.py input.ir
 ```
 # Reverse Compile Plutus back into Ladder Logic
 ```
-python src/reverse_compiler.py input.plutus
+python src/reverse_compiler/reverse_compiler.py input.plutus
 ```
 ### **Validate IR Structure**
 ```sh
-python src/validate_ir.py input.ir
+python src/validator_ir_transform.py input.ir
 ```
 # Example Workflow
 ```
-python src/ll_to_ir.py examples/sample.ll > output.ir
+python src/ll_parser.py examples/basic_example.ll > output.ir
 ```
 ```
-python src/compile_ir_to_plutus.py output.ir > output.plutus
+python src/plutusladder_compiler.py output.ir > output.plutus
 ```
 ```
-python src/reverse_compiler.py output.plutus > output_reversed.ll
+python src/reverse_compiler/reverse_compiler.py output.plutus > output_reversed.ll
 ```
 ---
 


### PR DESCRIPTION
## Summary
- update README script names to reflect repo
- point workflow to `examples/basic_example.ll`