### PR TITLE
Fix indentation of arithmetic test

### DIFF
--- a/tests/test_plutusladder_compiler.py
+++ b/tests/test_plutusladder_compiler.py
@@ -27,13 +27,13 @@ class TestPlutusLadderCompiler(unittest.TestCase):
         )
         self.assertIn("traceIfFalse", compile_ir_to_plutus_haskell_enhanced(ir_data))
 
-def test_arithmetic_operations(self):
-    ir_data = {
-        "math_operations": {
-            "C": {"operation": "ADD", "args": ["A", "B"]}
+    def test_arithmetic_operations(self):
+        ir_data = {
+            "math_operations": {
+                "C": {"operation": "ADD", "args": ["A", "B"]}
+            }
         }
-    }
-    expected_output = (
-        'traceIfFalse "Addition failed" (C == A + B)\n'
-    )
-    self.assertIn("traceIfFalse", compile_ir_to_plutus_haskell_enhanced(ir_data))
+        expected_output = (
+            'traceIfFalse "Addition failed" (C == A + B)\n'
+        )
+        self.assertIn("traceIfFalse", compile_ir_to_plutus_haskell_enhanced(ir_data))


### PR DESCRIPTION
## Summary
- indent `test_arithmetic_operations` so it belongs to `TestPlutusLadderCompiler`

## Testing
- `pytest -q` *(fails: ValueError Invalid IR input, AssertionError for ReverseCompiler tests)*

------
https://chatgpt.com/codex/tasks/task_e_6850e81d35ec8320ac85cae1b1239062